### PR TITLE
Updates default values for the Helm Chart

### DIFF
--- a/charts/scroll-proving-sindri/values.yaml
+++ b/charts/scroll-proving-sindri/values.yaml
@@ -29,13 +29,15 @@ persistence:
     mountPath: /keys/
     size: 10Mi
     accessMode: ReadWriteOnce
+
 service:
   main:
-    enabled: true
+    enabled: false
     ports:
       http:
         enabled: true
         port: 80
+
 defaultProbes: &default_probes
   enabled: true
   custom: true
@@ -43,13 +45,9 @@ defaultProbes: &default_probes
     httpGet:
       path: "/"
       port: 80
-probes:
-  liveness:
-    !!merge <<: *default_probes
-  readiness:
-    !!merge <<: *default_probes
-  startup:
-    !!merge <<: *default_probes
+
+probes: null
+
 # scrollConfig should be overwritten the config in json format. See the example below.
 scrollConfig: |
   {}

--- a/charts/scroll-proving-sindri/values.yaml
+++ b/charts/scroll-proving-sindri/values.yaml
@@ -2,21 +2,25 @@
 global:
   nameOverride: &app_name scroll-proving-sindri
   fullnameOverride: *app_name
+
 image:
   repository: ghcr.io/sindri-labs/sindri-scroll-sdk/prover
   pullPolicy: Always
   tag: ""
+
 command:
   - "/bin/sh"
   - "-c"
   - "exec sindri-scroll-sdk --config /sdk_prover/config.json"
+
 resources:
   requests:
     memory: "100Mi"
     cpu: "50m"
   limits:
     memory: "500Mi"
-    cpu: "100m"
+    cpu: "1000m"
+
 persistence:
   config:
     enabled: true


### PR DESCRIPTION
# Updates Default Values

- Increase the CPU limit from 100m to 1000m
- Disable the service creation since we are not serving any endpoints
- Disable the startup / liveness / readiness probes to avoid pods being killed by k8s