### PR TITLE
Update config.json `base_url` to match other Sindri SDKs

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -15,7 +15,7 @@
         "circuit_version": "v0.13.1",
         "n_workers": 1,
         "cloud": {
-            "base_url": "https://sindri.app/api/v1/",
+            "base_url": "https://sindri.app",
             "api_key": "<your Sindri API key>",
             "retry_count": 3,
             "retry_wait_time_sec": 5,

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ impl CloudProver {
         let api_url = base_url.join(SINDRI_API_PATH).expect("cannot parse cloud prover api_url");
 
         Self {
-            api_url,
+            base_url: api_url,
             api_key: cfg.api_key,
             send_timeout: Duration::from_secs(cfg.connection_timeout_sec),
             client,

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,10 @@ fn reprocess_prove_input(req: &ProveRequest) -> anyhow::Result<String> {
 // alternatively, we can just read it from the config
 const THIS_CIRCUIT_VERSION: &str = "v0.13.1";
 
+// Sindri API client path. This is the base path for all
+// Sindri API calls in this version of the Sindri Scroll SDK.
+const SINDRI_API_PATH: &str = "/api/v1/";
+
 impl CloudProver {
     pub fn new(cfg: CloudProverConfig) -> Self {
         let retry_wait_duration = Duration::from_secs(cfg.retry_wait_time_sec);
@@ -290,9 +294,10 @@ impl CloudProver {
             .build();
 
         let base_url = Url::parse(&cfg.base_url).expect("cannot parse cloud prover base_url");
+        let api_url = base_url.join(SINDRI_API_PATH).expect("cannot parse cloud prover api_url");
 
         Self {
-            base_url,
+            api_url,
             api_key: cfg.api_key,
             send_timeout: Duration::from_secs(cfg.connection_timeout_sec),
             client,


### PR DESCRIPTION
## Description
This change allows the Sindri API version supported by all releases of this code to be specified within the code itself, following convention with other Sindri SDKs.

### References
* https://github.com/Sindri-Labs/sindri-python
* https://github.com/Sindri-Labs/sindri-js

## Testing
- [x] update your local `config.json` file as noted in `example.config.json` in this PR.
- [x] invoke `cargo run --release` and see successful Sindri API communication.