### PR TITLE
Add CI lint action (clippy) and README badges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
       - name: Run Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Clippy
-        run: cargo clippy --all-features
+        run: cargo clippy -- -D warnings
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-features
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           profile: minimal
           override: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Lint Codebase
+name: CI Workflows
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     - ready_for_review
 
 jobs:
-  run-lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     # Do not run on draft pull requests
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
@@ -22,4 +22,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features    
+        run: cargo clippy --all-targets --all-features
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-index-
 
+      - name: Install Clippy
+        run: rustup component add clippy
+
       - name: Run Clippy
-        run: cargo clippy --all-features
+        run: cargo clippy
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: Lint Codebase
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # Do not run on draft pull requests
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
+
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    # Do not run on draft pull requests
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features    

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sindri Provers for Scroll SDK
 
-[![Build](https://img.shields.io/github/actions/workflow/status/Sindri-Labs/sindri-scroll-sdk/ci.yaml?style=for-the-badge)](https://github.com/Sindri-Labs/sindri-scroll-sdk/actions)
+[![Build](https://img.shields.io/github/actions/workflow/status/Sindri-Labs/sindri-scroll-sdk/ci.yaml)](https://github.com/Sindri-Labs/sindri-scroll-sdk/actions)
 [![License](https://img.shields.io/github/license/Sindri-Labs/sindri-scroll-sdk)](https://img.shields.io/github/license/Sindri-Labs/sindri-scroll-sdk?style=for-the-badge)
 
 <img src="./media/sindri-gradient-logo.webp" height="160" align="right"/>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sindri Provers for Scroll SDK
 
+[![Build](https://img.shields.io/github/actions/workflow/status/Sindri-Labs/sindri-scroll-sdk/ci.yaml?style=for-the-badge)](https://github.com/Sindri-Labs/sindri-scroll-sdk/actions)
+[![License](https://img.shields.io/github/license/Sindri-Labs/sindri-scroll-sdk)](https://img.shields.io/github/license/Sindri-Labs/sindri-scroll-sdk?style=for-the-badge)
 
 <img src="./media/sindri-gradient-logo.webp" height="160" align="right"/>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,6 @@ impl ProvingService for CloudProver {
             };
         };
 
-        #[allow(dead_code)]
         #[derive(serde::Deserialize)]
         struct SindriCircuitInfoResponse {
             verification_key: VerificationKey,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+//! sindri-scroll-sdk
+//!
+//! This program connects the Sindri proving service to the Scroll proving SDK.
+//!
 use async_trait::async_trait;
 use clap::Parser;
 use core::time::Duration;
@@ -42,6 +46,7 @@ struct VerificationKey {
     verification_key: String,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize)]
 struct SindriTaskStatusResponse {
     pub proof_id: String,
@@ -94,8 +99,6 @@ fn reformat_vk(vk_old: String) -> anyhow::Result<String> {
     // encode with padding
     let vk_new = base64::encode_config(vk, base64::STANDARD);
 
-    log::debug!("vk_new: {:?}", vk_new);
-
     Ok(vk_new)
 }
 
@@ -105,6 +108,11 @@ impl ProvingService for CloudProver {
         false
     }
 
+    // There are three steps to prove a circuit:
+    // 1. Get the verification key from the Sindri proving service.
+    // 2. Submit a proof to the Sindri proving service.
+    // 3. Query the status of the proof task.
+
     async fn get_vk(&self, req: GetVkRequest) -> GetVkResponse {
         if req.circuit_version != THIS_CIRCUIT_VERSION {
             return GetVkResponse {
@@ -113,6 +121,7 @@ impl ProvingService for CloudProver {
             };
         };
 
+        #[allow(dead_code)]
         #[derive(serde::Deserialize)]
         struct SindriGetDetailResponse {
             circuit_id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,19 +46,13 @@ struct VerificationKey {
     verification_key: String,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
-struct SindriTaskStatusResponse {
+struct SindriProofInfoResponse {
     pub proof_id: String,
-    pub project_name: String,
-    pub perform_verify: bool,
     pub status: SindriTaskStatus,
     pub compute_time_sec: Option<f64>,
-    pub queue_time_sec: Option<f64>,
     pub verification_key: Option<VerificationKey>,
     pub proof: Option<serde_json::Value>,
-    pub public: Option<serde_json::Value>,
-    pub warnings: Option<Vec<String>>,
     pub error: Option<String>,
 }
 
@@ -123,14 +117,12 @@ impl ProvingService for CloudProver {
 
         #[allow(dead_code)]
         #[derive(serde::Deserialize)]
-        struct SindriGetDetailResponse {
-            circuit_id: String,
-            circuit_name: String,
+        struct SindriCircuitInfoResponse {
             verification_key: VerificationKey,
         }
 
         match self
-            .get_with_token::<SindriGetDetailResponse>(
+            .get_with_token::<SindriCircuitInfoResponse>(
                 MethodClass::Circuit(req.circuit_type),
                 "detail",
                 None,
@@ -173,7 +165,7 @@ impl ProvingService for CloudProver {
         };
 
         match self
-            .post_with_token::<SindriProveRequest, SindriTaskStatusResponse>(
+            .post_with_token::<SindriProveRequest, SindriProofInfoResponse>(
                 MethodClass::Circuit(req.circuit_type),
                 "prove",
                 &sindri_req,
@@ -212,7 +204,7 @@ impl ProvingService for CloudProver {
         .collect();
 
         match self
-            .get_with_token::<SindriTaskStatusResponse>(
+            .get_with_token::<SindriProofInfoResponse>(
                 MethodClass::Proof(req.task_id.clone()),
                 "detail",
                 Some(query_params),


### PR DESCRIPTION
Add CI action which:
- caches the cargo registry and index (in order to speed subsequent testing)
- runs "clippy" linting
- builds the project
- tests the project (no tests currently present)

Also show in README.md two new badges:
- status of the above CI actions
- code license

## Reviewer Notes

- [x] Check the "checks" actions: https://github.com/Sindri-Labs/sindri-scroll-sdk/actions/runs/11581681177/job/32242982509?pr=17
<img width="1009" alt="Screenshot 2024-10-29 at 3 06 12 PM" src="https://github.com/user-attachments/assets/341e71e5-ec6c-4f72-b833-2f8bcb19bc91">

- [x] Examine the new README at https://github.com/Sindri-Labs/sindri-scroll-sdk/tree/gu-pass-clippy and verify the badges.
<img width="993" alt="Screenshot 2024-10-29 at 2 38 32 PM" src="https://github.com/user-attachments/assets/072c1dc8-e490-40ef-9d99-59a301c83de5">
