### PR TITLE
Updating documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ flowchart LR
 
 For more information about the Sindri platform, please check out [sindri.app](https://sindri.app/).
 The next section ([Getting Started](#getting-started)) shows how to launch a local Scroll SDK devote with provers running on Sindri.
-For production deployments, please consult the official [Scroll SDK documentation](https://docs.scroll.xyz/en/sdk/guides/production-deployment/).
+For production deployments, please consult the official [Scroll SDK documentation](https://docs.scroll.io/en/sdk/guides/production-deployment/).
 
 # Getting Started
 
-While this section primarily reiterates [Scroll's Devnet Guide](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/), it includes adjustments specifically for Ubuntu environments.
+While this section primarily reiterates [Scroll's Devnet Guide](https://docs.scroll.io/en/sdk/guides/devnet-deployment/), it includes adjustments specifically for Ubuntu environments.
 This guide also makes revisions to launch the coordinator service which acts as a gateway between the sequencing layer and Sindri provers.
 Since the coordinator requires at least 20 GB of RAM, we recommend you use a machine with at least 32 GB available.
 
@@ -61,7 +61,7 @@ You will need to obtain an API key to use Sindri.
 If you have not already created an account, you can do so by visiting the [Sindri sign up page](https://sindri.app/signup).
 After logging into the [Sindri front-end](https://sindri.app/login), you can create and manage your API Keys within the [API Keys Settings page](https://sindri.app/z/me/page/settings/api-keys).
 
-You should also install `docker`, `kubectl`, `minikube`, `helm`, `node`, and `scrollsdk` as instructed by the official [Scroll SDK documentation](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/#prerequisites).
+You should also install `docker`, `kubectl`, `minikube`, `helm`, `node`, and `scrollsdk` as instructed by the official [Scroll SDK documentation](https://docs.scroll.io/en/sdk/guides/devnet-deployment/#prerequisites).
 
 You should initialize your `minikube` environment with three commands:
 ```bash
@@ -132,7 +132,7 @@ Now, you should add mappings for the Scroll SDK services to your local DNS resol
 ```
 
 You should be able to access the endpoints via your browser.
-[This section](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/#web-uis) of the Scroll SDK documentation provides an explanation of all the available dashboards.
+[This section](https://docs.scroll.io/en/sdk/guides/devnet-deployment/#web-uis) of the Scroll SDK documentation provides an explanation of all the available dashboards.
 
 ### 🚀 Launching Sindri Provers
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ flowchart LR
 
 For more information about the Sindri platform, please check out [sindri.app](https://sindri.app/).
 The next section ([Getting Started](#getting-started)) shows how to launch a local Scroll SDK devote with provers running on Sindri.
-For production deployments, please consult the official [Scroll SDK documentation](https://docs.scroll.io/en/sdk/guides/production-deployment/).
+For production deployments, please consult the official [Scroll SDK documentation](https://docs.scroll.io/en/sdk/).
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <img src="./media/sindri-gradient-logo.webp" height="160" align="right"/>
 
-#### [Sindri Sign Up](https://sindri.app/signup) | [Scroll SDK Docs](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/) | [Getting Started](#getting-started) | [Development](#internal-development)
+#### [Sindri Sign Up](https://sindri.app/signup) | [Scroll SDK Docs](https://docs.scroll.io/en/sdk) | [Getting Started](#getting-started) | [Development](#internal-development)
 
 Sindri provides automated ZK proving infrastructure, empowering hundreds of teams—including leading Layer 2s and rollups—to launch in minutes instead of months.
 Through the Sindri API, developers can seamlessly integrate verifiable computation, reducing time to market, cutting costs, and scaling faster.
@@ -47,11 +47,11 @@ flowchart LR
 
 For more information about the Sindri platform, please check out [sindri.app](https://sindri.app/).
 The next section ([Getting Started](#getting-started)) shows how to launch a local Scroll SDK devote with provers running on Sindri.
-For production deployments, please consult the official [Scroll SDK documentation](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/guides/production-deployment/).
+For production deployments, please consult the official [Scroll SDK documentation](https://docs.scroll.xyz/en/sdk/guides/production-deployment/).
 
 # Getting Started
 
-While this section primarily reiterates [Scroll's Devnet Guide](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/guides/devnet-deployment/), it includes adjustments specifically for Ubuntu environments.
+While this section primarily reiterates [Scroll's Devnet Guide](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/), it includes adjustments specifically for Ubuntu environments.
 This guide also makes revisions to launch the coordinator service which acts as a gateway between the sequencing layer and Sindri provers.
 Since the coordinator requires at least 20 GB of RAM, we recommend you use a machine with at least 32 GB available.
 
@@ -61,7 +61,7 @@ You will need to obtain an API key to use Sindri.
 If you have not already created an account, you can do so by visiting the [Sindri sign up page](https://sindri.app/signup).
 After logging into the [Sindri front-end](https://sindri.app/login), you can create and manage your API Keys within the [API Keys Settings page](https://sindri.app/z/me/page/settings/api-keys).
 
-You should also install `docker`, `kubectl`, `minikube`, `helm`, `node`, and `scrollsdk` as instructed by the official [Scroll SDK documentation](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/guides/devnet-deployment/#prerequisites).
+You should also install `docker`, `kubectl`, `minikube`, `helm`, `node`, and `scrollsdk` as instructed by the official [Scroll SDK documentation](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/#prerequisites).
 
 You should initialize your `minikube` environment with three commands:
 ```bash
@@ -132,7 +132,7 @@ Now, you should add mappings for the Scroll SDK services to your local DNS resol
 ```
 
 You should be able to access the endpoints via your browser.
-[This section](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/guides/devnet-deployment/#web-uis) of the Scroll SDK documentation provides an explanation of all the available dashboards.
+[This section](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/#web-uis) of the Scroll SDK documentation provides an explanation of all the available dashboards.
 
 ### 🚀 Launching Sindri Provers
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <img src="./media/sindri-gradient-logo.webp" height="160" align="right"/>
 
-#### [Sindri Sign Up](https://sindri.app/signup) | [Scroll SDK Docs](https://docs.scroll.io/en/sdk) | [Getting Started](#getting-started) | [Development](#internal-development)
+#### [Sindri Sign Up](https://sindri.app/signup) | [Scroll SDK Docs](https://docs.scroll.io/en/sdk/) | [Getting Started](#getting-started) | [Development](#internal-development)
 
 Sindri provides automated ZK proving infrastructure, empowering hundreds of teams—including leading Layer 2s and rollups—to launch in minutes instead of months.
 Through the Sindri API, developers can seamlessly integrate verifiable computation, reducing time to market, cutting costs, and scaling faster.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,11 +1,11 @@
 # Deploy Sindri Provers
 
-This demo builds on the minikube deployment of [Scroll SDK](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/guides/devnet-deployment/).
+This demo builds on the minikube deployment of [Scroll SDK](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/).
 
 
 ## Prerequisites
 
-Before you attempt to launch the proving layers make sure that you have already completed the deployment of all other services in [Scroll SDK](https://scroll-sdk-init.docs.scroll.xyz/en/sdk/guides/devnet-deployment/) using minikube.
+Before you attempt to launch the proving layers make sure that you have already completed the deployment of all other services in [Scroll SDK](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/) using minikube.
 Here are two easy heuristics to ensure that all pods are healthy and you are ready to launch the provers:
 * run `kubectl get pods` and ensure that `coordinator-api-0` has a status of `Running` 
 * run `scrollsdk test ingress` and ensure that all URLs are reachable.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,11 +1,11 @@
 # Deploy Sindri Provers
 
-This demo builds on the minikube deployment of [Scroll SDK](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/).
+This demo builds on the minikube deployment of [Scroll SDK](https://docs.scroll.io/en/sdk/guides/devnet-deployment/).
 
 
 ## Prerequisites
 
-Before you attempt to launch the proving layers make sure that you have already completed the deployment of all other services in [Scroll SDK](https://docs.scroll.xyz/en/sdk/guides/devnet-deployment/) using minikube.
+Before you attempt to launch the proving layers make sure that you have already completed the deployment of all other services in [Scroll SDK](https://docs.scroll.io/en/sdk/guides/devnet-deployment/) using minikube.
 Here are two easy heuristics to ensure that all pods are healthy and you are ready to launch the provers:
 * run `kubectl get pods` and ensure that `coordinator-api-0` has a status of `Running` 
 * run `scrollsdk test ingress` and ensure that all URLs are reachable.


### PR DESCRIPTION
This PR updates our outward Scroll documentation links.  While we previously pointed to the temporary location of the Scroll SDK docs, the permanent location is now available.

## Reviewer Instructions
- [ ] Ensure all link revisions are unbroken
- [ ] Search for uncaught old temp links (grepping for `scroll-sdk-init` would suffice)