### PR TITLE
Update scroll-prover-sdk commit hash to latest commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 # Core Scroll dependencies
 prover_darwin = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.12.2", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
 prover_darwin_v2 = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.13.1", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
-scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "30def05"}
+scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "18aeeda"}
 
 [patch.crates-io]
 ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }

--- a/example.config.json
+++ b/example.config.json
@@ -15,7 +15,7 @@
         "circuit_version": "v0.13.1",
         "n_workers": 1,
         "cloud": {
-            "base_url": "https://sindri.app/api/v1/",
+            "base_url": "https://sindri.app",
             "api_key": "<your Sindri API key>",
             "retry_count": 3,
             "retry_wait_time_sec": 5,

--- a/example.config.json
+++ b/example.config.json
@@ -2,24 +2,25 @@
     "prover_name_prefix": "sindri_",
     "keys_dir": "keys",
     "coordinator": {
-        "base_url": "https://your-coordinator-api",
+        "base_url": "https://coordinator-ap:80",
         "retry_count": 3,
         "retry_wait_time_sec": 5,
         "connection_timeout_sec": 60
     },
     "l2geth": {
-        "endpoint": "https://your-l2-rpc"
+        "endpoint": "https://l2-rpc:8545"
     },
     "prover": {
         "circuit_type": 3,
         "circuit_version": "v0.13.1",
         "n_workers": 1,
         "cloud": {
-            "base_url": "https://sindri.app",
+            "base_url": "https://sindri.app/api/v1/",
             "api_key": "<your Sindri API key>",
             "retry_count": 3,
             "retry_wait_time_sec": 5,
             "connection_timeout_sec": 60
         }
-    }
+    },
+    "health_listener_addr": "0.0.0.0:5678"
 }

--- a/example.config.json
+++ b/example.config.json
@@ -2,7 +2,7 @@
     "prover_name_prefix": "sindri_",
     "keys_dir": "keys",
     "coordinator": {
-        "base_url": "https://coordinator-ap:80",
+        "base_url": "https://coordinator-api:80",
         "retry_count": 3,
         "retry_wait_time_sec": 5,
         "connection_timeout_sec": 60


### PR DESCRIPTION
This PR updates the import for the `scroll-proving-sdk` to use the latest commit hash.