### PR TITLE
Add created, started, finished timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,6 +4344,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
+ "chrono",
  "clap",
  "ctor 0.2.8",
  "env_logger 0.11.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.13.1"
+chrono = "0.4.38"
 clap = { version = "4.5", features = ["derive"] }
 ctor = "0.2.8"
 env_logger = "0.11.3"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs.
       - 📝 Explain any unusual or "clever" design decisions.
       - 📝 List any new dependencies added to Cargo.toml.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: CI builds DO NOT run on draft pull requests.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Closes #15" would connect the current pull
request to issue 15. Then when the pull request is merged, Github will
automatically close the issue.
-->

- Closes #13

## Description
Provide `created_at`, `started_at`, and `finished_at` values for `ProveResponse` (defined in the [Scroll proving SDK](https://github.com/scroll-tech/scroll-proving-sdk/blob/main/src/prover/proving_service.rs#L29)) from various values in the Sindri `ProofInfoResponse`.

## Developer Notes
Adds dependency `chrono = "0.4.38"` which provides `DateTime` objects.
Follow-up story #22 will move `fn proving_timestamps_from_response` and `fn iso8601_to_f64` to a new utils.rs file.

## Testing Instructions, Screenshots, Recordings

Run `RUST_LOG=trace cargo run --release`. This produces a lot of output, but eventually it peters out and we see a proof created and status is Queued. At this stage the new code has been invoked and you'll see something along the lines of:

```bash
...
2024-10-31T00:44:00.394700Z  INFO working_loop{i=0}: sindri_scroll_sdk: [Sindri client], detail, received response    
2024-10-31T00:44:00.394712Z DEBUG working_loop{i=0}: sindri_scroll_sdk: [Sindri client], detail, response: {"proof_id": "c8d364ea-5434-4aa8-9940-8769e679ca51", "circuit_name": "chunk_prover", "project_name": "chunk_prover", "circuit_id": "615cb64c-786f-416b-8a24-bba6c0c09810", "circuit_type": "halo2", "date_created": "2024-10-31T00:44:00.037Z", "meta": {}, "perform_verify": true, "status": "Queued", "verified": null, "team": "Graham Ullrich", "team_avatar_url": "https://gravatar.com/avatar/0a0a0c8aaa00ade50f74a3f0ca981ed7?s=400&d=identicon&r=x", "team_slug": "graham-ullrich", "circuit_team": "scroll-tech", "circuit_team_avatar_url": "https://static.stage.sindri.app/team_avatars/066df0f2-b614-7dea-8000-0118f4a9d517.png", "circuit_team_slug": "scroll-tech", "compute_time": null, "compute_time_sec": null, "compute_times": null, "file_size": null, "proof": null, "public": null, "queue_time": null, "queue_time_sec": null, "smart_contract_calldata": null, "has_smart_contract_calldata": false, "has_verification_key": true, "verification_key": null, "warnings": null, "error": null}    
2024-10-31T00:44:00.394915Z TRACE working_loop{i=0}: sindri_scroll_sdk: resp.date_created: "2024-10-31T00:44:00.037Z" date_created: 2024-10-31T00:44:00.037+00:00 date_created.timestamp(): 1730335440 created_at: 1730335440.037 started_at: None finished_at: None    
2024-10-31T00:44:00.394948Z  INFO working_loop{i=0}: scroll_proving_sdk::prover: Task status update prover_name="sindri_0" task_type=Chunk coordinator_task_uuid="f1b8a717-777f-4a9d-b4e8-06e2236f1430" coordinator_task_id="0xee9cbe5b71300e4f0cbefd1c3af33a6112b6f81268f06e95913b64bd29a75c02" proving_service_task_id="c8d364ea-5434-4aa8-9940-8769e679ca51" status=Queued
```

From this sample, examine the penultimate line:

`2024-10-31T00:44:00.394915Z TRACE working_loop{i=0}: sindri_scroll_sdk: resp.date_created: "2024-10-31T00:44:00.037Z" date_created: 2024-10-31T00:44:00.037+00:00 date_created.timestamp(): 1730335440 created_at: 1730335440.037 started_at: None finished_at: None`

This shows:
- `resp.date_created` - `ProofInfoResponse.date_created` ISO-8601 string
- `date_created` - a string representation of the resulting `chrono::DateTime` generated from`resp.date_created`
- `date_created.timestamp()` - the `DateTime.timestamp`
- `created_at`
- `started_at`
- `finished_at`

The last three values are Rust `f64` timestamp values generated from the `ProofInfoResponse` content and subsequently assigned to the `ProverResponse`.
The `started_at` and `finished_at` fields only get set after the proof is started and completed respectively, so while the proof is queued they both will be None and while in the process of proving `finished_at` will be None.

In terms of testing, I added the TRACE log statement seen above, and expected `created_at` to be essentially the same as `date_created.timestamp()`.

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: Tests cannot reference code in main.rs for binary packages. Follow-up story: [ Re-organize code to allow tests #22](https://github.com/Sindri-Labs/sindri-scroll-sdk/issues/22).
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![blastoff](https://media.giphy.com/media/utz68KlKM5LGBVF6HZ/giphy.gif?cid=790b7611jis4l174jpydo8zcoxwwdsi0rnfhr73k2pt1202c&ep=v1_gifs_search&rid=giphy.gif&ct=g)