### PR TITLE
Update /demo directory for v0.0.3

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -36,7 +36,7 @@ Generally, the latest stable release is safe to use with the latest Scroll SDK c
 
 Now, you can launch all Scroll zkEVM proving services with one command via 
    ```bash
-   SINDRI_VERSION=0.0.2 ./deploy.sh
+   SINDRI_VERSION=0.0.3 ./deploy.sh
    ```
 Running `kubectl get pods` should reveal three new services, one for each circuit type.
 Assuming your chain has proving tasks, you can monitor the progress of proof generation either via the logs of any prover pod or via Sindri's web front-end after logging in:

--- a/demo/values/prover-batch-demo.yaml
+++ b/demo/values/prover-batch-demo.yaml
@@ -27,7 +27,7 @@ scrollConfig: |
       "circuit_version": "v0.13.1",
       "n_workers": 1,
       "cloud": {
-        "base_url": "https://sindri.app/api/v1/",
+        "base_url": "https://sindri.app",
         "api_key": "<your-api-key>",
         "retry_count": 3,
         "retry_wait_time_sec": 5,

--- a/demo/values/prover-bundle-demo.yaml
+++ b/demo/values/prover-bundle-demo.yaml
@@ -27,7 +27,7 @@ scrollConfig: |
       "circuit_version": "v0.13.1",
       "n_workers": 1,
       "cloud": {
-        "base_url": "https://sindri.app/api/v1/",
+        "base_url": "https://sindri.app",
         "api_key": "<your-api-key>",
         "retry_count": 3,
         "retry_wait_time_sec": 5,

--- a/demo/values/prover-chunk-demo.yaml
+++ b/demo/values/prover-chunk-demo.yaml
@@ -27,7 +27,7 @@ scrollConfig: |
         "circuit_version": "v0.13.1",
         "n_workers": 1,
         "cloud": {
-          "base_url": "https://sindri.app/api/v1/",
+          "base_url": "https://sindri.app",
           "api_key": "<your-api-key>",
           "retry_count": 3,
           "retry_wait_time_sec": 5,


### PR DESCRIPTION
## Description
Updates the sindri-scroll-prover version from v0.0.2 to v0.0.3.  The api url endpoints have been updated for each of the three images from `"https://sindri.app/api/v1/"` to `"https://sindri.app/"`.


## Testing Instructions
Launch a local devnet using the procedure outlined in the sindri-scroll-sdk [readme](https://github.com/Sindri-Labs/sindri-scroll-sdk/blob/main/README.md).

Monitor the pods using either:
- `kubectl get pods`
- minikube dashboard

Once the `coordinator-api pod` is running, launch the sindri-prover pods.

1. Navigate to the `/demo` directory and run:
```bash
cd values
cp prover-batch-demo.yaml prover-batch-local.yaml
cp prover-bundle-demo.yaml prover-bundle-local.yaml
cp prover-chunk-demo.yaml prover-chunk-local.yaml
cd ..
``` 
Enter your API key in each of the three yaml files in the `/value` directory.
2. Run:
```bash
SINDRI_VERSION=0.0.3 ./deploy.sh
```
3.  Ensure that chunk, batch, and bundle prover pods are running using `kubectl` or the minikube GUI.
4. In the scroll-sdk directory, navigate to `/devnet/scroll-sdk`.
5. Run:
```bash
scrollsdk helper activity -o -t
```
This will generate transactions on the local devnet.  The chunk prover should initiate a proof job after ~50-100 L2 transactions have been processed.  This can take 2-3 minutes.

6.  Monitor django admin to see that a chunk proof job has been submitted.
Very this using the following command:
`kubectl logs <chunk-prover pod name>`

You should see a similar log output to the one below:
```bash
2024-10-31T23:15:59.764271Z TRACE working_loop{i=0}: sindri_scroll_sdk: resp.date_created: "2024-10-31T23:09:16.247Z" created_at: 1730416156.247 started_at: Some(1730416156.882265) finished_at: None    
2024-10-31T23:15:59.764285Z  INFO working_loop{i=0}: scroll_proving_sdk::prover: Task status update prover_name="sindri_chunk_0" task_type=Chunk coordinator_task_uuid="b3b370c0-a7d1-4e15-b601-b6a7392a676b" coordinator_task_id="0xaa2ca6fb4e4acc872d551de2bac18394fd163be21c27bd385adf3fffe7ea7268" proving_service_task_id="f070189c-379f-44ee-888b-db5c203ead45" status=Proving
```



