### PR TITLE
Updates from `scroll-proving-sdk`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+# Ignore local rust builds
 /target
-config.json
 
+# Ignore artifacts produced by local development
+config.json
+db/
+keys/
+!keys/.gitkeep
+
+# Ignore custom values files
 demo/values/*
 !demo/values/*-demo.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +548,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -704,6 +773,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +806,15 @@ dependencies = [
  "jobserver",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -762,6 +851,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1135,6 +1235,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dotenvy"
@@ -2552,16 +2658,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.10.0+7.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe4d5874f5ff2bc616e55e8c6086d478fcda13faf9495768a4aa1c22042d30b"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys 2.0.13+zstd.1.5.6",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2613,6 +2762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4-sys"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2779,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maybe-rayon"
@@ -2642,6 +2807,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2753,6 +2924,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3121,6 +3302,12 @@ dependencies = [
  "digest 0.10.7",
  "hmac",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3795,6 +3982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015439787fce1e75d55f279078d33ff14b4af5d93d995e8838ee4631301c8a99"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "ruint"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,13 +4202,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-proving-sdk"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/scroll-proving-sdk.git?rev=30def05#30def0596a5ab92954d8f932328d377ed6f9d98f"
+source = "git+https://github.com/scroll-tech/scroll-proving-sdk.git?rev=93b045c#93b045c8144f947901d3e31a528a0231b19e84e6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "base64 0.13.1",
  "clap",
  "ctor 0.2.8",
+ "dotenv",
  "env_logger 0.11.3",
  "eth-keystore",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -4022,15 +4221,16 @@ dependencies = [
  "http 1.1.0",
  "log",
  "once_cell",
- "prover 0.12.0",
  "prover 0.13.0",
  "rand",
  "reqwest 0.12.4",
  "reqwest-middleware",
  "reqwest-retry",
  "rlp",
+ "rocksdb",
  "serde",
  "serde_json",
+ "serde_stacker",
  "sled",
  "snark-verifier-sdk",
  "tiny-keccak",
@@ -4212,6 +4412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_stacker"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,6 +4527,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4839,6 +5055,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4859,6 +5076,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5630,13 +5848,23 @@ name = "zstd-safe"
 version = "7.0.0"
 source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack/mul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
 dependencies = [
- "zstd-sys",
+ "zstd-sys 2.0.9+zstd.1.5.5",
 ]
 
 [[package]]
 name = "zstd-sys"
 version = "2.0.9+zstd.1.5.5"
 source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack/mul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4582,6 +4582,7 @@ dependencies = [
  "serde_json",
  "serde_stacker",
  "sled",
+ "temp-env",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -4841,6 +4842,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.3",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 # Core Scroll dependencies
 prover_darwin = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.12.2", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
 prover_darwin_v2 = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.13.1", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
-scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "18aeeda"}
+scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "93b045c"}
 
 [patch.crates-io]
 ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 serde_stacker = "0.1"
 sled = "0.34.7"
+temp-env = "0.3.6"
 tiny-keccak = { version = "2.0.0", features = ["sha3", "keccak"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"

--- a/demo/README.md
+++ b/demo/README.md
@@ -36,7 +36,7 @@ Generally, the latest stable release is safe to use with the latest Scroll SDK c
 
 Now, you can launch all Scroll zkEVM proving services with one command via 
    ```bash
-   SINDRI_VERSION=0.0.3 ./deploy.sh
+   SINDRI_VERSION=0.0.4 ./deploy.sh
    ```
 Running `kubectl get pods` should reveal three new services, one for each circuit type.
 Assuming your chain has proving tasks, you can monitor the progress of proof generation either via the logs of any prover pod or via Sindri's web front-end after logging in:

--- a/demo/values/prover-batch-demo.yaml
+++ b/demo/values/prover-batch-demo.yaml
@@ -8,6 +8,12 @@ persistence:
     type: configMap
     mountPath: /sdk_prover/
     name: prover-batch-config
+  db:
+    enabled: true
+    type: pvc
+    mountPath: /db/
+    size: 10Mi
+    accessMode: ReadWriteOnce
 
 scrollConfig: |
   {

--- a/demo/values/prover-batch-demo.yaml
+++ b/demo/values/prover-batch-demo.yaml
@@ -13,6 +13,7 @@ scrollConfig: |
   {
     "prover_name_prefix": "sindri_batch_",
     "keys_dir": "keys",
+    "db_path": "db",
     "coordinator": {
       "base_url": "http://coordinator-api:80",
       "retry_count": 3,

--- a/demo/values/prover-bundle-demo.yaml
+++ b/demo/values/prover-bundle-demo.yaml
@@ -13,6 +13,7 @@ scrollConfig: |
   {
     "prover_name_prefix": "sindri_bundle_",
     "keys_dir": "keys",
+    "db_path": "db",
     "coordinator": {
       "base_url": "http://coordinator-api:80",
       "retry_count": 3,

--- a/demo/values/prover-bundle-demo.yaml
+++ b/demo/values/prover-bundle-demo.yaml
@@ -8,6 +8,12 @@ persistence:
     type: configMap
     mountPath: /sdk_prover/
     name: prover-bundle-config
+  db:
+    enabled: true
+    type: pvc
+    mountPath: /db/
+    size: 10Mi
+    accessMode: ReadWriteOnce
 
 scrollConfig: |
   {

--- a/demo/values/prover-chunk-demo.yaml
+++ b/demo/values/prover-chunk-demo.yaml
@@ -8,6 +8,12 @@ persistence:
         type: configMap
         mountPath: /sdk_prover/
         name: prover-chunk-config
+    db:
+      enabled: true
+      type: pvc
+      mountPath: /db/
+      size: 10Mi
+      accessMode: ReadWriteOnce
 
 scrollConfig: |
     {

--- a/demo/values/prover-chunk-demo.yaml
+++ b/demo/values/prover-chunk-demo.yaml
@@ -13,6 +13,7 @@ scrollConfig: |
     {
       "prover_name_prefix": "sindri_chunk_",
       "keys_dir": "keys",
+      "db_path": "db",
       "coordinator": {
         "base_url": "http://coordinator-api:80",
         "retry_count": 3,

--- a/example.config.json
+++ b/example.config.json
@@ -1,6 +1,7 @@
 {
     "prover_name_prefix": "sindri_",
     "keys_dir": "keys",
+    "db_path": "db",
     "coordinator": {
         "base_url": "https://coordinator-api:80",
         "retry_count": 3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     init_tracing();
 
     let args = Args::parse();
-    let cfg: Config = Config::from_file(args.config_file)?;
+    let cfg: Config = Config::from_file_and_env(args.config_file)?;
     let cloud_prover = CloudProver::new(
         cfg.prover
             .cloud

--- a/tests/init_config_test.rs
+++ b/tests/init_config_test.rs
@@ -12,6 +12,8 @@ async fn test_config_without_envs() {
     // Check a few values for consistency with test_data file
     assert_eq!(cfg.prover_name_prefix, "sindri_");
     assert_eq!(cfg.prover.circuit_type, CircuitType::Bundle);
+    assert_eq!(cfg.db_path, "db");
+    assert_eq!(cfg.prover.n_workers, 1_usize);
 }
 
 // Ensures that various environment variable overrides are successful

--- a/tests/init_config_test.rs
+++ b/tests/init_config_test.rs
@@ -1,0 +1,57 @@
+use scroll_proving_sdk::{config::Config, prover::CircuitType};
+use sindri_scroll_sdk::prover::CloudProver;
+use std::env::set_var;
+
+// Ensures that configuration file loading does not require environment variables
+#[tokio::test]
+async fn test_config_without_envs() {
+    let default_config_path = "tests/test_data/default_config.json";
+    let cfg: Config = Config::from_file_and_env(default_config_path.to_string())
+        .expect("Issue loading test configuration file");
+
+    // Check a few values for consistency with test_data file
+    assert_eq!(cfg.prover_name_prefix, "sindri_");
+    assert_eq!(cfg.prover.circuit_type, CircuitType::Bundle);
+}
+
+// Ensures that various environment variable overrides are successful
+#[test]
+fn test_config_with_envs() {
+    // Establish some environment variable overrides
+
+    set_var("N_WORKERS", "10");
+    set_var("COORDINATOR_BASE_URL", "my-special-coordinator");
+
+    let default_config_path = "tests/test_data/default_config.json";
+    let cfg: Config = Config::from_file_and_env(default_config_path.to_string())
+        .expect("Issue loading test configuration file");
+
+    // Ensure override was successful
+    assert_eq!(
+        cfg.prover.n_workers, 10_usize,
+        "Number of workers override was not successful"
+    );
+    assert_eq!(
+        cfg.coordinator.base_url, "my-special-coordinator",
+        "Coordinator base url override was not successful"
+    );
+}
+
+// Ensures that our understanding of the configuration file matches `scroll-proving-sdk`
+// expectations.  If this test fails, investigate recent updates upstream and ensure
+// example `config.json` files are accurate
+#[tokio::test]
+async fn test_initialize_from_config_pipeline() {
+    let default_config_path = "tests/test_data/default_config.json";
+    let cfg: Config = Config::from_file_and_env(default_config_path.to_string())
+        .expect("Issue loading test configuration file");
+
+    // Ensure that a cloud prover may be built from the config file
+    let _cloud_prover = CloudProver::new(
+        cfg.prover
+            .cloud
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Missing cloud prover configuration"))
+            .expect("Issue instantiating cloud prover in config tests"),
+    );
+}

--- a/tests/init_config_test.rs
+++ b/tests/init_config_test.rs
@@ -41,7 +41,7 @@ fn test_config_with_envs() {
 
 // Ensures that our understanding of the configuration file matches `scroll-proving-sdk`
 // expectations.  If this test fails, investigate recent updates upstream and ensure
-// example `config.json` files are accurate
+// example `config.json` files are accurate.
 #[tokio::test]
 async fn test_initialize_from_config_pipeline() {
     let default_config_path = "tests/test_data/default_config.json";

--- a/tests/init_config_test.rs
+++ b/tests/init_config_test.rs
@@ -1,6 +1,5 @@
 use scroll_proving_sdk::{config::Config, prover::CircuitType};
 use sindri_scroll_sdk::prover::CloudProver;
-use std::env::{remove_var, set_var};
 
 // Ensures that configuration file loading does not require environment variables
 #[tokio::test]
@@ -22,31 +21,37 @@ fn test_config_with_envs() {
     // Establish some environment variable overrides
 
     let num_workers_env_name = "N_WORKERS";
-    let num_workers_override = 10_usize;
-
+    let num_workers_override = "10";
     let coordinator_url_env_name = "COORDINATOR_BASE_URL";
     let coordinator_url_override = "my-special-coordinator";
 
-    set_var(num_workers_env_name, num_workers_override.to_string());
-    set_var(coordinator_url_env_name, coordinator_url_override);
+    // The utility function below sets environment variables for the duration of the closure.
+    // A singleton mutex ensures that the other test, test_config_without_envs, is not 
+    // influenced by these environment variable settings.
+    temp_env::with_vars(
+        [
+            (num_workers_env_name, Some(num_workers_override)),
+            (coordinator_url_env_name, Some(coordinator_url_override)),
+        ],
+        || {
+            let default_config_path = "tests/test_data/default_config.json";
+            let cfg: Config = Config::from_file_and_env(default_config_path.to_string())
+                .expect("Issue loading test configuration file");
 
-    let default_config_path = "tests/test_data/default_config.json";
-    let cfg: Config = Config::from_file_and_env(default_config_path.to_string())
-        .expect("Issue loading test configuration file");
-
-    // Ensure override was successful
-    assert_eq!(
-        cfg.prover.n_workers, num_workers_override,
-        "Number of workers override was not successful"
+            // Ensure override was successful
+            assert_eq!(
+                cfg.prover.n_workers,
+                num_workers_override
+                    .parse::<usize>()
+                    .expect("Unable to parse `n_workers` value into usize type"),
+                "Number of workers override was not successful"
+            );
+            assert_eq!(
+                cfg.coordinator.base_url, coordinator_url_override,
+                "Coordinator base url override was not successful"
+            );
+        },
     );
-    assert_eq!(
-        cfg.coordinator.base_url, coordinator_url_override,
-        "Coordinator base url override was not successful"
-    );
-
-    // Unset the test overrides so that other tests are n
-    remove_var(num_workers_env_name);
-    remove_var(coordinator_url_env_name);
 }
 
 // Ensures that our understanding of the configuration file matches `scroll-proving-sdk`

--- a/tests/init_config_test.rs
+++ b/tests/init_config_test.rs
@@ -1,6 +1,6 @@
 use scroll_proving_sdk::{config::Config, prover::CircuitType};
 use sindri_scroll_sdk::prover::CloudProver;
-use std::env::set_var;
+use std::env::{remove_var, set_var};
 
 // Ensures that configuration file loading does not require environment variables
 #[tokio::test]
@@ -21,8 +21,14 @@ async fn test_config_without_envs() {
 fn test_config_with_envs() {
     // Establish some environment variable overrides
 
-    set_var("N_WORKERS", "10");
-    set_var("COORDINATOR_BASE_URL", "my-special-coordinator");
+    let num_workers_env_name = "N_WORKERS";
+    let num_workers_override = 10_usize;
+
+    let coordinator_url_env_name = "COORDINATOR_BASE_URL";
+    let coordinator_url_override = "my-special-coordinator";
+
+    set_var(num_workers_env_name, num_workers_override.to_string());
+    set_var(coordinator_url_env_name, coordinator_url_override);
 
     let default_config_path = "tests/test_data/default_config.json";
     let cfg: Config = Config::from_file_and_env(default_config_path.to_string())
@@ -30,13 +36,17 @@ fn test_config_with_envs() {
 
     // Ensure override was successful
     assert_eq!(
-        cfg.prover.n_workers, 10_usize,
+        cfg.prover.n_workers, num_workers_override,
         "Number of workers override was not successful"
     );
     assert_eq!(
-        cfg.coordinator.base_url, "my-special-coordinator",
+        cfg.coordinator.base_url, coordinator_url_override,
         "Coordinator base url override was not successful"
     );
+
+    // Unset the test overrides so that other tests are n
+    remove_var(num_workers_env_name);
+    remove_var(coordinator_url_env_name);
 }
 
 // Ensures that our understanding of the configuration file matches `scroll-proving-sdk`

--- a/tests/test_data/default_config.json
+++ b/tests/test_data/default_config.json
@@ -1,0 +1,27 @@
+{
+    "prover_name_prefix": "sindri_",
+    "keys_dir": "keys",
+    "db_path": "db",
+    "coordinator": {
+        "base_url": "https://coordinator-api:80",
+        "retry_count": 3,
+        "retry_wait_time_sec": 5,
+        "connection_timeout_sec": 60
+    },
+    "l2geth": {
+        "endpoint": "https://l2-rpc:8545"
+    },
+    "prover": {
+        "circuit_type": 3,
+        "circuit_version": "v0.13.1",
+        "n_workers": 1,
+        "cloud": {
+            "base_url": "https://sindri.app",
+            "api_key": "<your Sindri API key>",
+            "retry_count": 3,
+            "retry_wait_time_sec": 5,
+            "connection_timeout_sec": 60
+        }
+    },
+    "health_listener_addr": "0.0.0.0:5678"
+}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs.
       - 📝 Explain any unusual or "clever" design decisions.
       - 📝 List any new dependencies added to Cargo.toml.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: CI builds DO NOT run on draft pull requests.
-->

## Description

This PR brings our provers up to date with the latest changes upstream in `scroll-proving-sdk`.  [Here](https://github.com/scroll-tech/scroll-proving-sdk/compare/18aeedabdd647c9f0566c8fa801c1e76c826c287...93b045c8144f947901d3e31a528a0231b19e84e6) is the full scope of changes from `18aeeda` to `93b045c`.



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Closes #15" would connect the current pull
request to issue 15. Then when the pull request is merged, Github will
automatically close the issue.
-->

- Related Issue #27
- Closes #26 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Developer Notes

The changes from commit `18aeeda` to `93b045c` include:

#### Env overrides for special `config.json` fields
Users can now supply prover configuration parameters via a combination of an input file and environment variables.  A config file is still required, there is no way to initialize solely based on environment variables.  In particular, the file is read in first - so conflicts between environment variables and the file are always resolved by the env overrides.  Note that not all fields in the config file permit an override, see [list here](https://github.com/scroll-tech/scroll-proving-sdk/blob/93b045c8144f947901d3e31a528a0231b19e84e6/src/config.rs#L94)

#### Task resume logic
A [task cache](https://github.com/scroll-tech/scroll-proving-sdk/pull/49) database component is now included in a `Prover` struct.  The intention of this task cache is to resume the tracking of progress on a proof that has been submitted to a cloud prover.  For instance, you may notice that when you shut down the sindri prover and start it back up currently, the coordinator tells you that you already have a task checked out and gives you an error.  This latest version we are upgrading to avoids that by adding a key value pair to a [rocksdb](https://rocksdb.org/) struct.  

Specifically the way this works is:
* When you cold-start a prover, it will enter a loop with no tasks started.  Upon being sent a task from the coordinator, it inserts {`prover_public_key`: `proving_task_id`} into the DB.
* When that task is done, the same key-value pair is removed. (The DB either has 0 or 1 entries at any point)
* Now, if something happens during execution and your prover goes down, the saved state of the DB does not.  The next time you bring up a prover, it will find the last `proving_task_id` in the DB and continue to just poll that job.
* One facet of this solution that I find very interesting, is that you can stop your prover in one circuit mode (`circuit_type == 2` say) and restart it in another mode.  The DB will just return that you have a task checked out.  The prover polls for that task and sends it back when it is done.  The next task it asks for corresponds to the circuit type you are currently running under.  
  * This is really non-consequential when running in a kubernetes deployment since the spawned DB's will all be separate, but I was curious what would happen for us in local development, so I tested to confirm what I was reading in the code.

## Testing Instructions, Screenshots, Recordings

- [x] Reviewer should run `cargo test` to ensure the configuration file tests pass
- [x] Reviewer should run `cargo build --release` (after modifying their `config.json`) to see how the new task cache fits in

- [x] Katie will post the results of running `v0.0.4-rc1` after building the release candidates from this branch

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

[Note] - I attempted to add tests for the task cache, however, we are at a disadvantage because our package is downstream of the codebase where the DB functionality is defined.  What I mean is that the tests I had in mind initialized a prover and then did some basic insertion/deletion of tasks without requiring a realistic coordinator client.  However, the `db` struct inside a prover is private.  Reason I chose to abandon this effort was because the more natural place for testing that functionality is upstream.

## [optional] What gif best describes this PR or how it makes you feel?

![reborn](https://github.com/user-attachments/assets/9a408e64-b612-4a1d-b2ce-58010e4cae19)
