### PR TITLE
Remove `Content-Encoding: gzip` header from requests and fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           override: true
 
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     env:
       # Necessary to get librocksdb to compile.
-      CXXFLAGS: "-O3 -std=c++17 -include cstdint"
+      CXXFLAGS: "-std=c++17 -include cstdint"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     # Do not run on draft pull requests
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    env:
+      # Necessary to get librocksdb to compile.
+      CXXFLAGS: "-O3 -std=c++17 -include cstdint"
 
     steps:
       - name: Checkout code

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use core::time::Duration;
 use reqwest::{
-    header::{CONTENT_ENCODING, CONTENT_TYPE},
+    header::{CONTENT_TYPE},
     Url,
 };
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
@@ -380,7 +380,6 @@ impl CloudProver {
         let resp_builder = resp_builder
             .timeout(self.send_timeout)
             .header(CONTENT_TYPE, "application/json")
-            .header(CONTENT_ENCODING, "gzip")
             .bearer_auth(&self.api_key);
 
         let response = resp_builder.send().await?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,9 +1,6 @@
 use async_trait::async_trait;
 use core::time::Duration;
-use reqwest::{
-    header::{CONTENT_TYPE},
-    Url,
-};
+use reqwest::{header::CONTENT_TYPE, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
A `Content-Encoding: gzip` header was being added to prover requests, but the request bodies weren't actually being compressed. Now that we've added decompression middleware to our backend, this incorrect header would lead it to parse the body as gzip which would result in a 500 error. This PR removes the incorrect header, and there will be a follow-up to actually compress the request bodies.

In order to get CI to pass, I also had to set `CXXFLAGS` to include `-std=c++17 -include cstdint` in order for librocksdb to compile. I ran into the same thing when running locally. While looking at CI, I noticed that the v2 cache action is deprecated and about to be removed, so this additionally bumps it to v4. See: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down