### PR TITLE
Enable zstd request and response compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,15 +375,17 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-compression"
-version = "0.4.10"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
 dependencies = [
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd 0.13.2",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -466,7 +468,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -1298,7 +1300,7 @@ name = "encoder"
 version = "0.1.0"
 source = "git+https://github.com/scroll-tech/da-codec.git?tag=v0.1.0#5a28b752d4504bf0966734fe4a6a5433981c74c2"
 dependencies = [
- "zstd",
+ "zstd 0.13.0",
 ]
 
 [[package]]
@@ -2392,9 +2394,26 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.23.21",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tower-service",
 ]
 
 [[package]]
@@ -3719,7 +3738,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -3727,15 +3746,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3747,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -3762,6 +3781,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
+ "hyper-rustls 0.27.5",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3776,7 +3796,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3798,7 +3818,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "serde",
  "thiserror",
  "tower-service",
@@ -3818,7 +3838,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.3.1",
  "parking_lot 0.11.2",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "reqwest-middleware",
  "retry-policies",
  "tokio",
@@ -4083,6 +4103,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -4124,6 +4157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4223,7 +4267,7 @@ dependencies = [
  "once_cell",
  "prover 0.13.0",
  "rand",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "reqwest-middleware",
  "reqwest-retry",
  "rlp",
@@ -4558,6 +4602,7 @@ name = "sindri-scroll-sdk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "async-trait",
  "base64 0.13.1",
  "chrono",
@@ -4573,7 +4618,7 @@ dependencies = [
  "prover 0.12.0",
  "prover 0.13.0",
  "rand",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "reqwest-middleware",
  "reqwest-retry",
  "rlp",
@@ -4817,6 +4862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,7 +5043,17 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls 0.23.21",
  "tokio",
 ]
 
@@ -5004,9 +5065,9 @@ checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
  "webpki-roots 0.23.1",
 ]
@@ -5171,7 +5232,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.21.12",
  "sha1",
  "thiserror",
  "url",
@@ -5850,7 +5911,16 @@ name = "zstd"
 version = "0.13.0"
 source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack/mul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.0.0",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -5859,6 +5929,15 @@ version = "7.0.0"
 source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack/mul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
 dependencies = [
  "zstd-sys 2.0.9+zstd.1.5.5",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys 2.0.13+zstd.1.5.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3805,6 +3805,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg 0.52.0",
 ]
@@ -4630,6 +4631,7 @@ dependencies = [
  "temp-env",
  "tiny-keccak",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5074,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5449,6 +5451,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasm-timer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+async-compression = { version = "0.4.18", features = ["tokio", "zstd"] }
 async-trait = "0.1"
 base64 = "0.13.1"
 chrono = "0.4.38"
@@ -18,7 +19,7 @@ http = "1.1.0"
 log = "0.4"
 once_cell = "1.19.0"
 rand = "0.8.5"
-reqwest = { version = "0.12.4", features = ["gzip"] }
+reqwest = { version = "0.12.4", features = ["zstd"] }
 reqwest-middleware = "0.3"
 reqwest-retry = "0.5"
 rlp = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = "1.1.0"
 log = "0.4"
 once_cell = "1.19.0"
 rand = "0.8.5"
-reqwest = { version = "0.12.4", features = ["zstd"] }
+reqwest = { version = "0.12.5", features = ["stream", "zstd"] }
 reqwest-middleware = "0.3"
 reqwest-retry = "0.5"
 rlp = "0.5.2"
@@ -30,6 +30,7 @@ sled = "0.34.7"
 temp-env = "0.3.6"
 tiny-keccak = { version = "2.0.0", features = ["sha3", "keccak"] }
 tokio = { version = "1.37.0", features = ["full"] }
+tokio-util = { version = "0.7.13", features = ["io"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod middleware;
 pub mod prover;
 pub mod utils;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,63 @@
+use async_compression::tokio::write::ZstdEncoder;
+use async_trait::async_trait;
+use http::Extensions;
+use reqwest::{header::HeaderValue, header::CONTENT_ENCODING, Body, Request, Response};
+use reqwest_middleware::{Middleware, Next, Result};
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::ReaderStream;
+
+const BUFFER_SIZE: usize = 4096;
+
+#[derive(Debug)]
+pub struct ZstdRequestCompressionMiddleware;
+
+#[async_trait]
+impl Middleware for ZstdRequestCompressionMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        // If the request has a body, compress it using zstd.
+        if let Some(bytes) = req.body().and_then(|b| b.as_bytes()) {
+            // Create a new request with the same properties.
+            let (method, url, headers, version) = (
+                req.method().clone(),
+                req.url().clone(),
+                req.headers().clone(),
+                req.version(),
+            );
+            let mut new_req = Request::new(method, url);
+            *new_req.headers_mut() = headers;
+            *new_req.version_mut() = version;
+
+            // Swap out the body with a zstd compressed stream of the original.
+            let (writer, reader) = tokio::io::duplex(BUFFER_SIZE);
+            let body_arc = Arc::new(bytes.to_vec());
+            let body_clone = Arc::clone(&body_arc);
+            tokio::spawn(async move {
+                let mut encoder = ZstdEncoder::new(writer);
+                if let Err(e) = encoder.write_all(&body_clone).await {
+                    log::error!("Failed to compress body: {}", e);
+                }
+                let _ = encoder.shutdown().await;
+            });
+            new_req
+                .body_mut()
+                .replace(Body::wrap_stream(ReaderStream::new(reader)));
+
+            // Set the `Content-Encoding: zstd` header.
+            new_req
+                .headers_mut()
+                .insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+
+            // Proceed with the new request.
+            return next.run(new_req, extensions).await;
+        }
+
+        // If no body needs to be compressed, proceed with the original request.
+        next.run(req, extensions).await
+    }
+}

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,3 +1,4 @@
+use crate::middleware::ZstdRequestCompressionMiddleware;
 use async_trait::async_trait;
 use core::time::Duration;
 use reqwest::{header::CONTENT_TYPE, Url};
@@ -283,6 +284,7 @@ impl CloudProver {
             .build_with_max_retries(cfg.retry_count);
         let client = ClientBuilder::new(reqwest::Client::new())
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .with(ZstdRequestCompressionMiddleware)
             .build();
 
         let base_url = Url::parse(&cfg.base_url).expect("cannot parse cloud prover base_url");

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -372,13 +372,16 @@ impl CloudProver {
         log::info!("[Sindri client]: {:?}", url.as_str());
 
         let resp_builder = match request_body {
-            Some(body) => self.client.post(url).body(body),
+            Some(body) => self
+                .client
+                .post(url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(body),
             None => self.client.get(url),
         };
 
         let resp_builder = resp_builder
             .timeout(self.send_timeout)
-            .header(CONTENT_TYPE, "application/json")
             .bearer_auth(&self.api_key);
 
         let response = resp_builder.send().await?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -282,11 +282,13 @@ impl CloudProver {
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(retry_wait_duration / 2, retry_wait_duration)
             .build_with_max_retries(cfg.retry_count);
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-            .with(ZstdRequestCompressionMiddleware)
-            .zstd(true) // Zstd response compression.
-            .build();
+        let client = ClientBuilder::new(
+            // Explicitly enable zstd response compression.
+            reqwest::Client::builder().zstd(true).build().unwrap(),
+        )
+        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+        .with(ZstdRequestCompressionMiddleware)
+        .build();
 
         let base_url = Url::parse(&cfg.base_url).expect("cannot parse cloud prover base_url");
         let api_url = base_url

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -285,6 +285,7 @@ impl CloudProver {
         let client = ClientBuilder::new(reqwest::Client::new())
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
             .with(ZstdRequestCompressionMiddleware)
+            .zstd(true) // Zstd response compression.
             .build();
 
         let base_url = Url::parse(&cfg.base_url).expect("cannot parse cloud prover base_url");


### PR DESCRIPTION
On the response side, this adds the `zstd` feature for the `reqwest` crate which automatically attaches an `Accept-Encoding: zstd` header to outgoing requests and decompresses responses with `Content-Encoding: zstd` headers. The request side was slightly trickier because there isn't built in support in `reqwest`. I implemented the compression here as a new `ZstdRequestCompressionMiddleware` which compresses request bodies as a stream if the body size is at least 512 bytes (a similar minimum size applies in our backend). I went with this approach because it's compatible with our request retry strategy and doesn't add extra request time by blocking on the compression.

A small unrelated change is that we were previously setting a `Content-Type: application/json` header on all requests, I updated this to only apply when there is a request body. Our backend tolerates this, but it's more correct to have it unset when there's no body imho.
